### PR TITLE
Sound event unification

### DIFF
--- a/common/src/main/java/dev/latvian/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/kubejs/BuiltinKubeJSPlugin.java
@@ -131,6 +131,8 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 
 		//sound
 		RegistryInfos.SOUND_EVENT.addType("basic", SoundEventBuilder.class, SoundEventBuilder::new);
+        //sound: backward compat
+        RegistryInfos.SOUND_EVENT.eventIds.add(KubeJSEvents.SOUND_REGISTRY);
 		//block
 		RegistryInfos.BLOCK.addType("basic", BlockBuilder.class, BlockBuilder::new);
 		RegistryInfos.BLOCK.addType("detector", DetectorBlock.Builder.class, DetectorBlock.Builder::new);

--- a/common/src/main/java/dev/latvian/kubejs/KubeJSOtherEventHandler.java
+++ b/common/src/main/java/dev/latvian/kubejs/KubeJSOtherEventHandler.java
@@ -1,17 +1,9 @@
 package dev.latvian.kubejs;
 
-import dev.latvian.kubejs.client.SoundRegistryEventJS;
-import dev.latvian.kubejs.script.ScriptType;
-import net.minecraft.sounds.SoundEvent;
-
 /**
  * @author LatvianModder
  */
 public class KubeJSOtherEventHandler {
     public static void init() {
-        new SoundRegistryEventJS(
-            id -> KubeJSRegistries.soundEvents().register(id, () -> new SoundEvent(id))
-        )
-            .post(ScriptType.STARTUP, KubeJSEvents.SOUND_REGISTRY);
     }
 }

--- a/common/src/main/java/dev/latvian/kubejs/client/SoundRegistryEventJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/client/SoundRegistryEventJS.java
@@ -1,21 +1,20 @@
 package dev.latvian.kubejs.client;
 
-import dev.latvian.kubejs.event.StartupEventJS;
+import dev.latvian.kubejs.registry.RegistryEventJS;
+import dev.latvian.kubejs.registry.RegistryInfos;
 import net.minecraft.resources.ResourceLocation;
-
-import java.util.function.Consumer;
+import net.minecraft.sounds.SoundEvent;
 
 /**
  * @author LatvianModder
  */
-public class SoundRegistryEventJS extends StartupEventJS {
-	private final Consumer<ResourceLocation> registry;
+public class SoundRegistryEventJS extends RegistryEventJS<SoundEvent> {
 
-	public SoundRegistryEventJS(Consumer<ResourceLocation> registry) {
-		this.registry = registry;
-	}
+    public SoundRegistryEventJS() {
+        super(RegistryInfos.SOUND_EVENT);
+    }
 
 	public void register(ResourceLocation r) {
-		registry.accept(r);
+		create(r.toString());
 	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/event/EventJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/event/EventJS.java
@@ -1,7 +1,12 @@
 package dev.latvian.kubejs.event;
 
 import dev.latvian.kubejs.script.ScriptType;
+import lombok.val;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author LatvianModder
@@ -24,31 +29,32 @@ public class EventJS {
 	protected void afterPosted(boolean result) {
 	}
 
-	public final boolean post(ScriptType t, @NotNull String id) {
-		if (t != ScriptType.STARTUP && post(ScriptType.STARTUP, id) && canCancel()) {
-			return true;
-		}
+    /**
+     * @param ids event ids to be used for posting events to handlers, they will be used in input order
+     * @return whether there's handlers called `event.cancel()` and this event itself can be cancelled
+     */
+    public final boolean post(@NotNull ScriptType type, @NotNull List<String> ids) {
+        if (type != ScriptType.STARTUP && post(ScriptType.STARTUP, ids) && canCancel()) {
+            return true;
+        }
+        val e = type.manager.get().events;
+        boolean cancelled = false;
+        for (val id : ids) {
+            if (cancelled) {
+                break; //prevent posting events after being cancelled
+            }
+            cancelled = e.postToHandlers(id, e.handlers(id), this);
+        }
+        afterPosted(cancelled);
+        return cancelled;
+    }
 
-		EventsJS e = t.manager.get().events;
-		boolean b = e.postToHandlers(id, e.handlers(id), this);
-		afterPosted(b);
-		return b;
+	public final boolean post(@NotNull ScriptType type, @NotNull String id) {
+		return post(type, Collections.singletonList(id));
 	}
 
 	public final boolean post(ScriptType t, String id, String sub) {
-		String id1 = id + '.' + sub;
-
-		if (t != ScriptType.STARTUP) {
-			EventsJS e = ScriptType.STARTUP.manager.get().events;
-			if ((e.postToHandlers(id1, e.handlers(id1), this) || e.postToHandlers(id, e.handlers(id), this)) && canCancel()) {
-				afterPosted(true);
-				return true;
-			}
-		}
-
-		EventsJS e = t.manager.get().events;
-		boolean b = e.postToHandlers(id1, e.handlers(id1), this) || e.postToHandlers(id, e.handlers(id), this);
-		afterPosted(b);
-		return b;
+        //id with sub id comes first to match original behaviour
+        return post(t, Arrays.asList(id + '.' + sub, id));
 	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/event/EventsJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/event/EventsJS.java
@@ -4,6 +4,8 @@ import dev.latvian.kubejs.script.ScriptManager;
 import dev.latvian.mods.rhino.RhinoException;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import lombok.val;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,26 +36,25 @@ public class EventsJS {
 		list.add(handler);
 	}
 
+    @NotNull
 	public List<IEventHandler> handlers(String id) {
-		List<IEventHandler> list = map.get(id);
-		return list == null ? Collections.emptyList() : list;
+        return map.getOrDefault(id, Collections.emptyList());
 	}
 
 	/**
 	 * @return true if there's one handler tried to cancel the event, and the event is cancellable
 	 */
-	public boolean postToHandlers(String id, List<IEventHandler> list, EventJS event) {
-		if (list.isEmpty()) {
+	public boolean postToHandlers(String id, List<IEventHandler> handlers, EventJS event) {
+		if (handlers.isEmpty()) {
 			return false;
 		}
 
-		boolean c = event.canCancel();
-
-		for (var handler : list) {
+        val canCancel = event.canCancel();
+		for (val handler : handlers) {
 			try {
 				handler.onEvent(event);
 
-				if (c && event.isCancelled()) {
+				if (canCancel && event.isCancelled()) {
 					return true;
 				}
 			} catch (RhinoException ex) {

--- a/common/src/main/java/dev/latvian/kubejs/registry/RegistryInfo.java
+++ b/common/src/main/java/dev/latvian/kubejs/registry/RegistryInfo.java
@@ -15,10 +15,7 @@ import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 
 /**
@@ -59,6 +56,7 @@ public final class RegistryInfo<T> implements Iterable<BuilderBase<? extends T>>
 	public String languageKeyPrefix;
 	//used for backward compatibility
 	public Supplier<RegistryEventJS<T>> customRegEvent;
+    public final List<String> eventIds;
 
 	private RegistryInfo(ResourceKey<? extends Registry<T>> key, Class<T> objectBaseClass) {
 		this.key = key;
@@ -69,7 +67,8 @@ public final class RegistryInfo<T> implements Iterable<BuilderBase<? extends T>>
 		this.autoWrap = objectBaseClass != Codec.class && objectBaseClass != ResourceLocation.class && objectBaseClass != String.class;
 		this.languageKeyPrefix = key.location().getPath().replace('/', '.');
 		this.customRegEvent = null;
-	}
+        eventIds = new ArrayList<>(Collections.singletonList(key.location().getPath() + KubeJSEvents.REGISTRY_SUFFIX));
+    }
 
 	public RegistryInfo<T> bypassServerOnly() {
 		this.bypassServerOnly = true;
@@ -125,7 +124,7 @@ public final class RegistryInfo<T> implements Iterable<BuilderBase<? extends T>>
 	}
 
 	@Nullable
-	public BuilderType getDefaultType() {
+	public BuilderType<T> getDefaultType() {
 		if (types.isEmpty()) {
 			return null;
 		} else if (defaultType == null) {
@@ -247,7 +246,7 @@ public final class RegistryInfo<T> implements Iterable<BuilderBase<? extends T>>
 		var event = customRegEvent == null
 				? new RegistryEventJS<>(this)
 				: customRegEvent.get();
-		event.post(ScriptType.STARTUP, key.location().getPath() + KubeJSEvents.REGISTRY_SUFFIX);
+		event.post(ScriptType.STARTUP, eventIds);
 		event.created.forEach(BuilderBase::createAdditionalObjects);
 	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/registry/RegistryInfos.java
+++ b/common/src/main/java/dev/latvian/kubejs/registry/RegistryInfos.java
@@ -2,6 +2,7 @@ package dev.latvian.kubejs.registry;
 
 import com.mojang.serialization.Codec;
 import dev.latvian.kubejs.block.events.BlockRegistryEventJS;
+import dev.latvian.kubejs.client.SoundRegistryEventJS;
 import dev.latvian.kubejs.item.events.ItemRegistryEventJS;
 import net.minecraft.core.Registry;
 import net.minecraft.core.particles.ParticleType;
@@ -71,7 +72,8 @@ public interface RegistryInfos {
     Map<ResourceKey<? extends Registry<?>>, RegistryInfo<?>> WITH_TYPE = Collections.synchronizedMap(new LinkedHashMap<>());
     List<BuilderBase<?>> ALL_BUILDERS = new ArrayList<>();
 
-    RegistryInfo<SoundEvent> SOUND_EVENT = RegistryInfo.of(Registry.SOUND_EVENT, SoundEvent.class);
+    RegistryInfo<SoundEvent> SOUND_EVENT = RegistryInfo.of(Registry.SOUND_EVENT, SoundEvent.class)
+        .customRegistryEvent(SoundRegistryEventJS::new);
     RegistryInfo<Fluid> FLUID = RegistryInfo.of(Registry.FLUID, Fluid.class);
     RegistryInfo<MobEffect> MOB_EFFECT = RegistryInfo.of(Registry.MOB_EFFECT, MobEffect.class).languageKeyPrefix("effect");
     RegistryInfo<Block> BLOCK = RegistryInfo.of(Registry.BLOCK, Block.class).customRegistryEvent(BlockRegistryEventJS::new);


### PR DESCRIPTION
- cleanup event posting logic, and allow posting events with multiple ids:
```java
someEvent.post(ScriptType.CLIENT, Arrays.asList("event.id", "anotherEventId", "a_third_custom_event_id"));
```
- make use of improved event posting to unify sound event registering