### PR TITLE
Registry events for modded registries

### DIFF
--- a/common/src/main/java/dev/latvian/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/kubejs/BuiltinKubeJSPlugin.java
@@ -465,7 +465,13 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
         typeWrappers.register(ItemTintFunction.class, ItemTintFunction::of);
 
         //registry
-        RegistryTypeWrapperFactory.register(typeWrappers);
+        for (val wrapperFactory : RegistryTypeWrapperFactory.getAll()) {
+            try {
+                typeWrappers.register(wrapperFactory.type, UtilsJS.cast(wrapperFactory));
+            } catch (IllegalArgumentException e) {
+                KubeJS.LOGGER.error("error when trying to register registry type wrapper: {}", wrapperFactory, e);
+            }
+        }
 
 		KubeJS.PROXY.clientTypeWrappers(typeWrappers);
 	}

--- a/common/src/main/java/dev/latvian/kubejs/KubeJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/KubeJS.java
@@ -140,8 +140,6 @@ public class KubeJS {
 		KubeJSServerEventHandler.init();
 		KubeJSRecipeEventHandler.init();
 
-		RegistryInfos.MAP.values().forEach(RegistryInfo::registerArch);
-
 		PROXY.init();
 	}
 

--- a/common/src/main/java/dev/latvian/kubejs/registry/RegistryInfo.java
+++ b/common/src/main/java/dev/latvian/kubejs/registry/RegistryInfo.java
@@ -26,16 +26,12 @@ import java.util.function.Supplier;
  */
 public final class RegistryInfo<T> implements Iterable<BuilderBase<? extends T>>, TypeWrapperFactory<T> {
 
+    @SuppressWarnings("unchecked")
     public static <T> RegistryInfo<T> of(ResourceKey<? extends Registry<?>> key, Class<T> type) {
-		val r = RegistryInfos.MAP.get(key);
-
-		if (r == null) {
-			val reg = new RegistryInfo<>(UtilsJS.cast(key), type);
-			RegistryInfos.MAP.put(key, reg);
-			return reg;
-		}
-
-		return (RegistryInfo<T>) r;
+        return (RegistryInfo<T>) RegistryInfos.MAP.computeIfAbsent(
+            key,
+            k -> new RegistryInfo<>(UtilsJS.cast(k), type)
+        );
 	}
 
     static <T> RegistryInfo<T> of(Registry<?> registry, Class<T> type) {
@@ -201,11 +197,7 @@ public final class RegistryInfo<T> implements Iterable<BuilderBase<? extends T>>
 		return archRegistry;
 	}
 
-	public Registry<T> getVanillaRegistry() {
-		return Registry.REGISTRY.get((ResourceKey) key);
-	}
-
-	public Set<Map.Entry<ResourceKey<T>, T>> entrySet() {
+    public Set<Map.Entry<ResourceKey<T>, T>> entrySet() {
 		return getArchRegistry().entrySet();
 	}
 

--- a/common/src/main/java/dev/latvian/kubejs/registry/RegistryInfo.java
+++ b/common/src/main/java/dev/latvian/kubejs/registry/RegistryInfo.java
@@ -59,8 +59,14 @@ public final class RegistryInfo<T> implements Iterable<BuilderBase<? extends T>>
 		this.objects = new LinkedHashMap<>();
 		this.bypassServerOnly = false;
 		this.autoWrap = type != Codec.class && type != ResourceLocation.class && type != String.class;
-		this.languageKeyPrefix = key.location().getPath().replace('/', '.');
-        eventIds = new ArrayList<>(Collections.singletonList(key.location().getPath() + KubeJSEvents.REGISTRY_SUFFIX));
+
+        val location = key.location();
+        val rawName = "minecraft".equals(location.getNamespace())
+            ? location.getPath()
+            : location.getNamespace() + '.' + location.getPath();
+
+        this.languageKeyPrefix = rawName.replace('/', '.');
+        eventIds = new ArrayList<>(Arrays.asList(rawName + KubeJSEvents.REGISTRY_SUFFIX));
     }
 
 	public RegistryInfo<T> bypassServerOnly() {

--- a/common/src/main/java/dev/latvian/kubejs/script/RegistryTypeWrapperFactory.java
+++ b/common/src/main/java/dev/latvian/kubejs/script/RegistryTypeWrapperFactory.java
@@ -4,37 +4,21 @@ import dev.latvian.kubejs.registry.RegistryInfo;
 import dev.latvian.kubejs.registry.RegistryInfos;
 import dev.latvian.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.util.wrap.TypeWrapperFactory;
-import dev.latvian.mods.rhino.util.wrap.TypeWrappers;
-import lombok.val;
 import me.shedaniel.architectury.registry.Registry;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RegistryTypeWrapperFactory<T> implements TypeWrapperFactory<T> {
 	private static List<RegistryTypeWrapperFactory<?>> all;
 
-    public static void register(TypeWrappers wrappers) {
-        for (val wrapperFactory : getAll()) {
-            try {
-                wrappers.register(wrapperFactory.type, UtilsJS.cast(wrapperFactory));
-            } catch (IllegalArgumentException ignored) {
-            }
-        }
-    }
-
 	public static List<RegistryTypeWrapperFactory<?>> getAll() {
         if (all == null) {
-            all = new ArrayList<>(RegistryInfos.MAP.size());
-            for (RegistryInfo info : RegistryInfos.MAP.values()) {
-                if (info.autoWrap) {
-                    all.add(new RegistryTypeWrapperFactory<>(
-                        info.type,
-                        info.getArchRegistry(),
-                        info.key.location().toString()
-                    ));
-                }
-            }
+            all = RegistryInfos.MAP.values()
+                .stream()
+                .filter(i -> i.autoWrap)
+                .map(RegistryTypeWrapperFactory::new)
+                .collect(Collectors.toList());
         }
         return all;
     }
@@ -42,6 +26,10 @@ public class RegistryTypeWrapperFactory<T> implements TypeWrapperFactory<T> {
 	public final Class<T> type;
 	public final Registry<T> registry;
 	public final String name;
+
+    private RegistryTypeWrapperFactory(RegistryInfo<T> info) {
+        this(info.type, info.getArchRegistry(), info.key.location().toString());
+    }
 
 	private RegistryTypeWrapperFactory(Class<T> type, Registry<T> registry, String name) {
 		this.type = type;

--- a/fabric/src/main/java/dev/latvian/kubejs/fabric/KubeJSFabric.java
+++ b/fabric/src/main/java/dev/latvian/kubejs/fabric/KubeJSFabric.java
@@ -3,6 +3,8 @@ package dev.latvian.kubejs.fabric;
 import dev.latvian.kubejs.KubeJS;
 import dev.latvian.kubejs.KubeJSEvents;
 import dev.latvian.kubejs.KubeJSInitializer;
+import dev.latvian.kubejs.registry.RegistryInfo;
+import dev.latvian.kubejs.registry.RegistryInfos;
 import dev.latvian.kubejs.script.ScriptType;
 import dev.latvian.kubejs.world.gen.fabric.WorldgenAddEventJSFabric;
 import dev.latvian.kubejs.world.gen.fabric.WorldgenRemoveEventJSFabric;
@@ -24,6 +26,7 @@ public class KubeJSFabric implements ModInitializer, ClientModInitializer, Dedic
                 initializer.onKubeJSInitialization();
                 KubeJS.LOGGER.debug("[KubeJS] Initialized entrypoint {}.", initializer.getClass().getSimpleName());
             }
+            RegistryInfos.MAP.values().forEach(RegistryInfo::registerArch);
             KubeJS.instance.setup();
 
             BiomeModifications.create(KubeJS.id("worldgen_removals"))

--- a/forge/src/main/java/dev/latvian/kubejs/forge/KubeJSForge.java
+++ b/forge/src/main/java/dev/latvian/kubejs/forge/KubeJSForge.java
@@ -11,10 +11,12 @@ import dev.latvian.kubejs.integration.IntegrationManager;
 import dev.latvian.kubejs.item.forge.ItemDestroyedEventJS;
 import dev.latvian.kubejs.item.ingredient.forge.CustomPredicateIngredient;
 import dev.latvian.kubejs.item.ingredient.forge.IgnoreNBTIngredient;
+import dev.latvian.kubejs.mixin.forge.AccessRegistryManager;
+import dev.latvian.kubejs.registry.RegistryInfo;
 import dev.latvian.kubejs.script.ScriptType;
 import dev.latvian.kubejs.server.ServerJS;
+import lombok.val;
 import me.shedaniel.architectury.platform.forge.EventBuses;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.Item;
@@ -34,7 +36,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.network.FMLNetworkConstants;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.*;
 import org.apache.commons.lang3.tuple.Pair;
 
 @Mod(KubeJS.MOD_ID)
@@ -45,6 +47,7 @@ public class KubeJSForge {
 		EventBuses.registerModEventBus(KubeJS.MOD_ID, bus);
 		bus.addListener(KubeJSForge::loadComplete);
 		//bus.addGenericListener(Block.class, EventPriority.LOW, KubeJSForge::initRegistries);
+        loadForgeRegistry();
 
 		KubeJS.instance = new KubeJS();
 		KubeJS.instance.setup();
@@ -72,13 +75,16 @@ public class KubeJSForge {
 			}
 		}
 
-		CraftingHelper.register(new ResourceLocation("kubejs", "custom_predicate"), CustomPredicateIngredient.SERIALIZER);
-		CraftingHelper.register(new ResourceLocation("kubejs", "ignore_nbt"), IgnoreNBTIngredient.SERIALIZER);
+		CraftingHelper.register(KubeJS.id("custom_predicate"), CustomPredicateIngredient.SERIALIZER);
+		CraftingHelper.register(KubeJS.id("ignore_nbt"), IgnoreNBTIngredient.SERIALIZER);
 	}
 
-	private static void initRegistries(RegistryEvent.Register<Block> event) {
-		//KubeJS.LOGGER.info("registering");
-	}
+    private static void loadForgeRegistry() {
+        val manager = (AccessRegistryManager) RegistryManager.ACTIVE;
+        for (val forgeRegistry : manager.kjs$registries().values()) {
+            RegistryInfo.of(forgeRegistry.getRegistryKey(), forgeRegistry.getRegistrySuperType());
+        }
+    }
 
 	private static void loadComplete(FMLLoadCompleteEvent event) {
 		KubeJS.instance.loadComplete();

--- a/forge/src/main/java/dev/latvian/kubejs/forge/KubeJSForge.java
+++ b/forge/src/main/java/dev/latvian/kubejs/forge/KubeJSForge.java
@@ -13,6 +13,7 @@ import dev.latvian.kubejs.item.ingredient.forge.CustomPredicateIngredient;
 import dev.latvian.kubejs.item.ingredient.forge.IgnoreNBTIngredient;
 import dev.latvian.kubejs.mixin.forge.AccessRegistryManager;
 import dev.latvian.kubejs.registry.RegistryInfo;
+import dev.latvian.kubejs.registry.RegistryInfos;
 import dev.latvian.kubejs.script.ScriptType;
 import dev.latvian.kubejs.server.ServerJS;
 import lombok.val;
@@ -45,9 +46,8 @@ public class KubeJSForge {
 		IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
 
 		EventBuses.registerModEventBus(KubeJS.MOD_ID, bus);
+        bus.addGenericListener(Block.class, KubeJSForge::onRegistry);
 		bus.addListener(KubeJSForge::loadComplete);
-		//bus.addGenericListener(Block.class, EventPriority.LOW, KubeJSForge::initRegistries);
-        loadForgeRegistry();
 
 		KubeJS.instance = new KubeJS();
 		KubeJS.instance.setup();
@@ -79,11 +79,13 @@ public class KubeJSForge {
 		CraftingHelper.register(KubeJS.id("ignore_nbt"), IgnoreNBTIngredient.SERIALIZER);
 	}
 
-    private static void loadForgeRegistry() {
+    private static void onRegistry(RegistryEvent.Register<Block> event) {
         val manager = (AccessRegistryManager) RegistryManager.ACTIVE;
         for (val forgeRegistry : manager.kjs$registries().values()) {
             RegistryInfo.of(forgeRegistry.getRegistryKey(), forgeRegistry.getRegistrySuperType());
         }
+
+        RegistryInfos.MAP.values().forEach(RegistryInfo::registerArch);
     }
 
 	private static void loadComplete(FMLLoadCompleteEvent event) {

--- a/forge/src/main/java/dev/latvian/kubejs/mixin/forge/AccessRegistryManager.java
+++ b/forge/src/main/java/dev/latvian/kubejs/mixin/forge/AccessRegistryManager.java
@@ -1,0 +1,19 @@
+package dev.latvian.kubejs.mixin.forge;
+
+import com.google.common.collect.BiMap;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+import net.minecraftforge.registries.RegistryManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * @author ZZZank
+ */
+@Mixin(value = RegistryManager.class, remap = false)
+public interface AccessRegistryManager {
+
+    @Accessor("registries")
+    BiMap<ResourceLocation, ForgeRegistry<? extends IForgeRegistryEntry<?>>> kjs$registries();
+}

--- a/forge/src/main/resources/kubejs.mixins.json
+++ b/forge/src/main/resources/kubejs.mixins.json
@@ -1,14 +1,15 @@
 {
-	"required": true,
-	"package": "dev.latvian.kubejs.mixin.forge",
-	"compatibilityLevel": "JAVA_8",
-	"mixins": [
-	],
-	"client": [
-		"EarlyLoaderGUIMixin"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	},
-	"minVersion": "0.8"
+  "required": true,
+  "package": "dev.latvian.kubejs.mixin.forge",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "AccessRegistryManager"
+  ],
+  "client": [
+    "EarlyLoaderGUIMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "minVersion": "0.8"
 }


### PR DESCRIPTION

Example:
![kessjs-registry-events](https://github.com/user-attachments/assets/3dccfefc-5c58-471b-8a5b-4f75c20f614d)

- [add forge registries into RegistryInfos](https://github.com/Hellish-Mods/KesseractJS/commit/c5d636a7cfcf79e2be847574a690bc4c50203843)
- [add log when error happens during RegistryTypeWrapperFactory registering](https://github.com/Hellish-Mods/KesseractJS/commit/5f20c485710cf6d675e9719a12997ae4ce3d7230)
- [cleanup methods in RegistryInfo](https://github.com/Hellish-Mods/KesseractJS/commit/6092e691566cd7d27c0553654b7ad0386955d6ff)

Note: Fabric registries are not supported, because Fabric is using vanilla registries, which unfortunately cannot provide enough information for creating new RegistryInfo